### PR TITLE
increase figure width

### DIFF
--- a/analysis/convert_images.py
+++ b/analysis/convert_images.py
@@ -3,7 +3,7 @@ import cairosvg
 from pathlib import Path
 
 def convert_image(image_path, output_path):
-    cairosvg.svg2png(url=str(image_path), write_to=str(output_path))
+    cairosvg.svg2png(url=str(image_path), write_to=str(output_path), output_width=1200, output_height=600)
 
 def parse_args():
     parser = argparse.ArgumentParser()

--- a/analysis/report.ipynb
+++ b/analysis/report.ipynb
@@ -70,7 +70,7 @@
     }
    ],
    "source": [
-    "Image(filename=\"../output/figures/incidence_twoway_rounded.png\", width=600)"
+    "Image(filename=\"../output/figures/incidence_twoway_rounded.png\", width=1200)"
    ]
   },
   {
@@ -373,7 +373,7 @@
    ],
    "source": [
     "\n",
-    "Image(filename=\"../output/figures/ITSA_diagnostic_delay_GP_newey.png\", width=600)"
+    "Image(filename=\"../output/figures/ITSA_diagnostic_delay_GP_newey.png\", width=1200)"
    ]
   },
   {
@@ -413,7 +413,7 @@
     }
    ],
    "source": [
-    "Image(filename=\"../output/figures/regional_qs2_bar_GP_merged.png\", width=600)"
+    "Image(filename=\"../output/figures/regional_qs2_bar_GP_merged.png\", width=1200)"
    ]
   },
   {
@@ -462,7 +462,7 @@
     }
    ],
    "source": [
-    "Image(filename=\"../output/figures/ITSA_csDMARD_delay_newey.png\", width=600)"
+    "Image(filename=\"../output/figures/ITSA_csDMARD_delay_newey.png\", width=1200)"
    ]
   },
   {
@@ -502,7 +502,7 @@
     }
    ],
    "source": [
-    "Image(filename=\"../output/figures/regional_csdmard_bar_merged.png\", width=600)"
+    "Image(filename=\"../output/figures/regional_csdmard_bar_merged.png\", width=1200)"
    ]
   },
   {
@@ -655,11 +655,11 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.9.6"
   },
   "vscode": {
    "interpreter": {
-    "hash": "ccecdc02aa416300a64487fe6971a8398ebaf053d2b2768f769ac21dbbf13f86"
+    "hash": "ac659f7751d67b9a7cdf73325e2e617dc9fd830cba372c10044997db2ad6bba6"
    }
   }
  },


### PR DESCRIPTION
Increases the figure width for figures in the report, fixes #16. It does this by manually setting the width when images are converted from svg to png and then making sure this width is used in the jupyter notebook. In the future we could look at being able to set different figure sizes for different images but I think this looks ok for the figures in the current report.